### PR TITLE
🎉ユーザが所属するグループ一覧を返すAPIの実装

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -18,6 +18,7 @@ func Engine(r *gin.Engine) *gin.Engine {
 	groupGroup := r.Group("/group")
 	{
 		groupGroup.POST("/add", group.AddGroupPost())
+		groupGroup.GET("/acquisition-affiliation-user", group.AcquisitionAffiliationUserGet())
 	}
 	pictureGroup := r.Group("/picture")
 	{

--- a/pkg/engine/group/affiliation.go
+++ b/pkg/engine/group/affiliation.go
@@ -1,0 +1,35 @@
+package group
+
+import (
+	"sns_backend/pkg/common/model"
+	"sns_backend/pkg/db/read"
+	"sns_backend/pkg/session"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ユーザが所属しているグループ一覧を取得
+func acquisitionAffiliationUserGet(c *gin.Context) {
+	data := session.Default(c, "session", &model.Session{}).Get(c)
+	if data == nil {
+		c.JSON(401, gin.H{
+			"message": "unauthorized",
+			"error":   "session not found",
+		})
+		return
+	}
+
+	groups, err := read.GetUsersGroup(data.(*model.Session).Username)
+	if err != nil {
+		c.JSON(500, gin.H{
+			"message": "internal server error",
+			"error":   "failed to get user's groups",
+		})
+		return
+	}
+
+	c.JSON(200, gin.H{
+		"message": "success",
+		"groups":  groups,
+	})
+}

--- a/pkg/engine/group/group_handller.go
+++ b/pkg/engine/group/group_handller.go
@@ -7,3 +7,7 @@ import (
 func AddGroupPost() gin.HandlerFunc {
 	return addGroupPost
 }
+
+func AcquisitionAffiliationUserGet() gin.HandlerFunc {
+	return acquisitionAffiliationUserGet
+}


### PR DESCRIPTION
ログイン済みのユーザが所属するグループ一覧を返すAPIを実装しました。

セッションからユーザ名を取得するのでパラメータは不必要