### PR TITLE
🔨picture/uploadのリクエスト値を変更

### DIFF
--- a/pkg/db/read/read.go
+++ b/pkg/db/read/read.go
@@ -109,23 +109,17 @@ func GetGroup(group_name string) (model.Group, error) {
 	return group, nil
 }
 
-// グループに所属するユーザを取得
-func GetGroupsUser(group_name string) ([]model.User, error) {
+// グループに所属するユーザを取得(グループIDから)
+func GetGroupsUserByGroupID(group_id int) ([]model.User, error) {
 	db := db.Connect()
 	defer db.Close()
-
-	// group_nameからグループ情報を取得
-	groupdata, err := GetGroup(group_name)
-	if err != nil {
-		return nil, err
-	}
 
 	sql := `SELECT "user"."user_id", "user"."nickname", "user"."username", "user"."password"
 			FROM "user"
 			JOIN "user_group" ON "user"."user_id" = "user_group"."user_id"
 			WHERE "user_group"."group_id" = $1`
 
-	rows, err := db.Query(sql, groupdata.Group_id)
+	rows, err := db.Query(sql, group_id)
 	if err != nil {
 		slog.Error("Error getting group's user: " + err.Error())
 		return nil, err

--- a/pkg/engine/picture/get.go
+++ b/pkg/engine/picture/get.go
@@ -31,17 +31,8 @@ func getPictureGet(c *gin.Context) {
 		return
 	}
 
-	group, err := read.GetGroupByID(GroupID)
-	if err != nil {
-		c.JSON(500, gin.H{
-			"message": "internal server error",
-			"error":   "failed to get group",
-		})
-		return
-	}
-
 	// ユーザがグループに所属しているか確認
-	users, err := read.GetGroupsUser(group.Group_name)
+	users, err := read.GetGroupsUserByGroupID(GroupID)
 	if err != nil {
 		c.JSON(500, gin.H{
 			"message": "internal server error",

--- a/pkg/engine/picture/upload.go
+++ b/pkg/engine/picture/upload.go
@@ -9,6 +9,7 @@ import (
 	"sns_backend/pkg/db/create"
 	"sns_backend/pkg/db/read"
 	"sns_backend/pkg/session"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 )
@@ -24,8 +25,15 @@ func uploadPost(c *gin.Context) {
 	}
 
 	// ユーザがグループに所属しているか確認
-	group_name := c.PostForm("group_name")
-	users, err := read.GetGroupsUser(group_name)
+	group_id, err := strconv.Atoi(c.PostForm("group_id"))
+	if err != nil {
+		c.JSON(400, gin.H{
+			"message": "bad request",
+			"error":   "invalid group_id",
+		})
+		return
+	}
+	users, err := read.GetGroupsUserByGroupID(group_id)
 	if err != nil {
 		c.JSON(500, gin.H{
 			"message": "internal server error",
@@ -48,8 +56,8 @@ func uploadPost(c *gin.Context) {
 		return
 	}
 
-	// グループIDを取得
-	group, err := read.GetGroup(group_name)
+	// グループ詳細を取得
+	group, err := read.GetGroupByID(group_id)
 	if err != nil {
 		c.JSON(500, gin.H{
 			"message": "internal server error",


### PR DESCRIPTION
picture/uploadにグループ名を投げると同じ名前のグループが存在していた場合に不具合が発生するので, 代わりにグループIDをリクエストに含めることでグループIDはunique値なので不具合を解消できる.